### PR TITLE
StorageExpressionEvaluationContext.unmountStorage

### DIFF
--- a/src/main/java/walkingkooka/storage/expression/function/FakeStorageExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/storage/expression/function/FakeStorageExpressionEvaluationContext.java
@@ -236,6 +236,11 @@ public class FakeStorageExpressionEvaluationContext extends FakeExpressionEvalua
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public void unmountStorage(final StoragePath path) {
+        throw new UnsupportedOperationException();
+    }
+
     // StorageContext...................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContext.java
+++ b/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContext.java
@@ -57,6 +57,8 @@ public interface StorageExpressionEvaluationContext extends ExpressionEvaluation
 
     void mountStoragePoint(final StorageMountPoint<?> mountPoint);
 
+    void unmountStorage(final StoragePath path);
+
     // EnvironmentContext...............................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextDelegator.java
+++ b/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextDelegator.java
@@ -149,5 +149,11 @@ public interface StorageExpressionEvaluationContextDelegator extends StorageExpr
             .mountStoragePoint(mountPoint);
     }
 
+    @Override
+    default void unmountStorage(final StoragePath path) {
+        this.storageExpressionEvaluationContext()
+            .unmountStorage(path);
+    }
+
     StorageExpressionEvaluationContext storageExpressionEvaluationContext();
 }

--- a/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextTesting2.java
+++ b/src/main/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextTesting2.java
@@ -131,6 +131,15 @@ public interface StorageExpressionEvaluationContextTesting2<C extends StorageExp
         );
     }
 
+    @Test
+    default void testUnmountStorageWithNullStoragePathFails() {
+        assertThrows(
+            NullPointerException.class,
+            () -> this.createContext()
+                .unmountStorage(null)
+        );
+    }
+
     @Override
     default C createCanDateTimeSymbolsForLocale() {
         return this.createContext();

--- a/src/test/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextDelegatorTest.java
+++ b/src/test/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextDelegatorTest.java
@@ -542,6 +542,14 @@ public final class StorageExpressionEvaluationContextDelegatorTest implements St
             );
         }
 
+        @Override
+        public void unmountStorage(final StoragePath path) {
+            this.storage.unmount(
+                path,
+                this
+            );
+        }
+
         private final Storage<StorageContext> storage = Storages.treeMapStore();
 
         @Override

--- a/src/test/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextTestingTest.java
+++ b/src/test/java/walkingkooka/storage/expression/function/StorageExpressionEvaluationContextTestingTest.java
@@ -495,6 +495,14 @@ public final class StorageExpressionEvaluationContextTestingTest implements Stor
             );
         }
 
+        @Override
+        public void unmountStorage(final StoragePath path) {
+            this.storage.unmount(
+                path,
+                this
+            );
+        }
+
         private final Storage<StorageContext> storage = Storages.treeMapStore();
 
         @Override


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-storage-expression-function/issues/171
- StorageExpressionEvaluationContext.unmount(StoragePath)